### PR TITLE
Add PE entrypoint address

### DIFF
--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -376,6 +376,18 @@ INT_PTR CALLBACK PvpPeGeneralDlgProc(
 
             if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
             {
+                string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.AddressOfEntryPoint);
+            }
+            else
+            {
+                string = PhFormatString(L"0x%I64x", ((PIMAGE_OPTIONAL_HEADER64)&PvMappedImage.NtHeaders->OptionalHeader)->AddressOfEntryPoint);
+            }
+
+            SetDlgItemText(hwndDlg, IDC_ENTRYPOINT, string->Buffer);
+            PhDereferenceObject(string);
+
+            if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
+            {
                 string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.ImageBase);
             }
             else

--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -376,18 +376,6 @@ INT_PTR CALLBACK PvpPeGeneralDlgProc(
 
             if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
             {
-                string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.AddressOfEntryPoint);
-            }
-            else
-            {
-                string = PhFormatString(L"0x%I64x", ((PIMAGE_OPTIONAL_HEADER64)&PvMappedImage.NtHeaders->OptionalHeader)->AddressOfEntryPoint);
-            }
-
-            SetDlgItemText(hwndDlg, IDC_ENTRYPOINT, string->Buffer);
-            PhDereferenceObject(string);
-
-            if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
-            {
                 string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.ImageBase);
             }
             else
@@ -396,6 +384,18 @@ INT_PTR CALLBACK PvpPeGeneralDlgProc(
             }
 
             SetDlgItemText(hwndDlg, IDC_IMAGEBASE, string->Buffer);
+            PhDereferenceObject(string);
+
+            if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
+            {
+                string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.AddressOfEntryPoint);
+            }
+            else
+            {
+                string = PhFormatString(L"0x%I64x", ((PIMAGE_OPTIONAL_HEADER64)&PvMappedImage.NtHeaders->OptionalHeader)->AddressOfEntryPoint);
+            }
+
+            SetDlgItemText(hwndDlg, IDC_ENTRYPOINT, string->Buffer);
             PhDereferenceObject(string);
 
             string = PhFormatString(L"0x%Ix (verifying...)", PvMappedImage.NtHeaders->OptionalHeader.CheckSum); // same for 32-bit and 64-bit images

--- a/tools/peview/peview.rc
+++ b/tools/peview/peview.rc
@@ -116,22 +116,22 @@ FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
     LTEXT           "Target machine:",IDC_STATIC,7,57,53,8
     LTEXT           "Static",IDC_TARGETMACHINE,78,57,215,8
-    LTEXT           "Checksum:",IDC_STATIC,7,102,36,8
-    LTEXT           "Static",IDC_CHECKSUM,78,102,215,8
-    LTEXT           "Subsystem:",IDC_STATIC,7,113,38,8
-    LTEXT           "Subsystem version:",IDC_STATIC,7,125,64,8
-    LTEXT           "Characteristics:",IDC_STATIC,7,136,51,8
-    LTEXT           "Static",IDC_SUBSYSTEM,78,113,215,8
-    LTEXT           "Static",IDC_SUBSYSTEMVERSION,78,125,215,8
+    LTEXT           "Checksum:",IDC_STATIC,7,100,36,8
+    LTEXT           "Static",IDC_CHECKSUM,78,100,215,8
+    LTEXT           "Subsystem:",IDC_STATIC,7,111,38,8
+    LTEXT           "Subsystem version:",IDC_STATIC,7,122,64,8
+    LTEXT           "Characteristics:",IDC_STATIC,7,133,51,8
+    LTEXT           "Static",IDC_SUBSYSTEM,78,111,215,8
+    LTEXT           "Static",IDC_SUBSYSTEMVERSION,78,122,215,8
     CONTROL         "",IDC_LIST,"SysListView32",LVS_REPORT | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,156,286,116
-    LTEXT           "Sections:",IDC_STATIC,7,147,30,8
-    EDITTEXT        IDC_CHARACTERISTICS,76,136,217,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
+    LTEXT           "Sections:",IDC_STATIC,7,146,30,8
+    EDITTEXT        IDC_CHARACTERISTICS,76,133,217,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
     LTEXT           "Time stamp:",IDC_STATIC,7,68,40,8
     LTEXT           "Static",IDC_TIMESTAMP,78,68,215,8
-    LTEXT           "Entry point:",IDC_STATIC,7,80,39,8
-    LTEXT           "Static",IDC_ENTRYPOINT,78,80,215,8
-    LTEXT           "Image base:",IDC_STATIC,7,91,41,8
-    LTEXT           "Static",IDC_IMAGEBASE,78,91,215,8
+    LTEXT           "Entry point:",IDC_STATIC,7,90,39,8
+    LTEXT           "Static",IDC_ENTRYPOINT,78,90,215,8
+    LTEXT           "Image base:",IDC_STATIC,7,79,41,8
+    LTEXT           "Static",IDC_IMAGEBASE,78,79,215,8
     ICON            "",IDC_FILEICON,14,18,20,20
     GROUPBOX        "File",IDC_FILE,7,7,286,48
     EDITTEXT        IDC_NAME,44,17,242,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
@@ -201,6 +201,11 @@ IDR_RT_MANIFEST         RT_MANIFEST             "peview.manifest"
 //
 
 IDD_PELOADCONFIG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_PEGENERAL AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/tools/peview/peview.rc
+++ b/tools/peview/peview.rc
@@ -114,24 +114,26 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSM
 CAPTION "General"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "Target machine:",IDC_STATIC,7,62,53,8
-    LTEXT           "Static",IDC_TARGETMACHINE,78,62,215,8
-    LTEXT           "Checksum:",IDC_STATIC,7,95,36,8
-    LTEXT           "Static",IDC_CHECKSUM,78,95,215,8
-    LTEXT           "Subsystem:",IDC_STATIC,7,106,38,8
-    LTEXT           "Subsystem version:",IDC_STATIC,7,117,64,8
-    LTEXT           "Characteristics:",IDC_STATIC,7,129,51,8
-    LTEXT           "Static",IDC_SUBSYSTEM,78,106,215,8
-    LTEXT           "Static",IDC_SUBSYSTEMVERSION,78,117,215,8
-    CONTROL         "",IDC_LIST,"SysListView32",LVS_REPORT | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,153,286,119
-    LTEXT           "Sections:",IDC_STATIC,7,143,30,8
-    EDITTEXT        IDC_CHARACTERISTICS,76,129,217,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
-    LTEXT           "Time stamp:",IDC_STATIC,7,73,40,8
-    LTEXT           "Static",IDC_TIMESTAMP,78,73,215,8
-    LTEXT           "Image base:",IDC_STATIC,7,84,41,8
-    LTEXT           "Static",IDC_IMAGEBASE,78,84,215,8
+    LTEXT           "Target machine:",IDC_STATIC,7,57,53,8
+    LTEXT           "Static",IDC_TARGETMACHINE,78,57,215,8
+    LTEXT           "Checksum:",IDC_STATIC,7,102,36,8
+    LTEXT           "Static",IDC_CHECKSUM,78,102,215,8
+    LTEXT           "Subsystem:",IDC_STATIC,7,113,38,8
+    LTEXT           "Subsystem version:",IDC_STATIC,7,125,64,8
+    LTEXT           "Characteristics:",IDC_STATIC,7,136,51,8
+    LTEXT           "Static",IDC_SUBSYSTEM,78,113,215,8
+    LTEXT           "Static",IDC_SUBSYSTEMVERSION,78,125,215,8
+    CONTROL         "",IDC_LIST,"SysListView32",LVS_REPORT | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,156,286,116
+    LTEXT           "Sections:",IDC_STATIC,7,147,30,8
+    EDITTEXT        IDC_CHARACTERISTICS,76,136,217,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
+    LTEXT           "Time stamp:",IDC_STATIC,7,68,40,8
+    LTEXT           "Static",IDC_TIMESTAMP,78,68,215,8
+    LTEXT           "Entry point:",IDC_STATIC,7,80,39,8
+    LTEXT           "Static",IDC_ENTRYPOINT,78,80,215,8
+    LTEXT           "Image base:",IDC_STATIC,7,91,41,8
+    LTEXT           "Static",IDC_IMAGEBASE,78,91,215,8
     ICON            "",IDC_FILEICON,14,18,20,20
-    GROUPBOX        "File",IDC_FILE,7,7,286,51
+    GROUPBOX        "File",IDC_FILE,7,7,286,48
     EDITTEXT        IDC_NAME,44,17,242,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
     EDITTEXT        IDC_COMPANYNAME,44,29,242,12,ES_AUTOHSCROLL | ES_READONLY | NOT WS_BORDER
     LTEXT           "Version:",IDC_STATIC,15,41,27,8

--- a/tools/peview/resource.h
+++ b/tools/peview/resource.h
@@ -26,6 +26,7 @@
 #define IDC_VERSION                     1013
 #define IDC_VERSIONSTRING               1014
 #define IDC_IMAGEBASE                   1015
+#define IDC_ENTRYPOINT                  1016
 #define IDC_NAME                        1044
 #define IDC_COMPANYNAME_LINK            1279
 
@@ -35,7 +36,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        108
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1016
+#define _APS_NEXT_CONTROL_VALUE         1017
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
This patch shows the AddressOfEntryPoint field from the OptionalHeader of any PE binary when viewed with peview.

There are two feature requests for this feature:
https://wj32.org/processhacker/forums/viewtopic.php?f=14&t=1803
https://wj32.org/processhacker/forums/viewtopic.php?f=14&t=2313