### PR TITLE
fix issue #41

### DIFF
--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -376,7 +376,7 @@ INT_PTR CALLBACK PvpPeGeneralDlgProc(
 
             if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
             {
-                string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.ImageBase);
+                string = PhFormatString(L"0x%I32x", ((PIMAGE_OPTIONAL_HEADER32)&PvMappedImage.NtHeaders->OptionalHeader)->ImageBase);
             }
             else
             {
@@ -388,7 +388,7 @@ INT_PTR CALLBACK PvpPeGeneralDlgProc(
 
             if (PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
             {
-                string = PhFormatString(L"0x%Ix", PvMappedImage.NtHeaders->OptionalHeader.AddressOfEntryPoint);
+                string = PhFormatString(L"0x%I32x", ((PIMAGE_OPTIONAL_HEADER32)&PvMappedImage.NtHeaders->OptionalHeader)->AddressOfEntryPoint);
             }
             else
             {


### PR DESCRIPTION
1) explicitly cast optional header to correct bitness, instead of allowing the compiler to decide based on the build environment. see 
[https://msdn.microsoft.com/en-us/library/windows/desktop/ms680339(v=vs.85).aspx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680339(v=vs.85).aspx) in the remarks section.
2) same for format string use "I32" insdead of "I" which allows the compiler to decide the size based on the build environment