### PR TITLE
PHNT header fixes

### DIFF
--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -2619,8 +2619,8 @@ typedef struct _KUSER_SHARED_DATA
     ULONGLONG RNGSeedVersion;
     ULONG GlobalValidationRunlevel;
     LONG TimeZoneBiasStamp;
-    ULONG Reserved2;
 
+    ULONG NtBuildNumber;
     ULONG NtProductType;
     BOOLEAN ProductTypeIsValid;
     UCHAR Reserved0[1];
@@ -2637,7 +2637,7 @@ typedef struct _KUSER_SHARED_DATA
     volatile ULONG TimeSlip;
 
     ALTERNATIVE_ARCHITECTURE_TYPE AlternativeArchitecture;
-    ULONG AltArchitecturePad[1];
+    ULONG BootId;
 
     LARGE_INTEGER SystemExpirationDate;
 
@@ -2668,7 +2668,8 @@ typedef struct _KUSER_SHARED_DATA
     ULONG NumberOfPhysicalPages;
 
     BOOLEAN SafeBootMode;
-    UCHAR Reserved12[3];
+    UCHAR VirtualizationFlags;
+    UCHAR Reserved12[2];
 
     union
     {
@@ -2683,14 +2684,18 @@ typedef struct _KUSER_SHARED_DATA
             ULONG DbgDynProcessorEnabled : 1;
             ULONG DbgConsoleBrokerEnabled : 1;
             ULONG DbgSecureBootEnabled : 1;
-            ULONG SpareBits : 24;
+            ULONG DbgMultiSessionSku : 1;
+            ULONG DbgMultiUsersInSessionSku : 1;
+            ULONG SpareBits : 22;
         };
     };
     ULONG DataFlagsPad[1];
 
     ULONGLONG TestRetInstruction;
-    ULONGLONG QpcFrequency;
-    ULONGLONG SystemCallPad[3];
+    LONGLONG QpcFrequency;
+    ULONG SystemCall;
+    ULONG SystemCallPad0;
+    ULONGLONG SystemCallPad[2];
 
     union
     {
@@ -2709,12 +2714,12 @@ typedef struct _KUSER_SHARED_DATA
     ULONGLONG BaselineInterruptTimeQpc;
     ULONGLONG QpcSystemTimeIncrement;
     ULONGLONG QpcInterruptTimeIncrement;
-    ULONG QpcSystemTimeIncrement32;
-    ULONG QpcInterruptTimeIncrement32;
     UCHAR QpcSystemTimeIncrementShift;
     UCHAR QpcInterruptTimeIncrementShift;
-    UCHAR Reserved8[14];
 
+    USHORT UnparkedProcessorCount;
+    ULONG EnclaveFeatureMask[4];
+    ULONG Reserved8;
     USHORT UserModeGlobalLogger[16];
     ULONG ImageFileExecutionOptions;
 
@@ -2723,7 +2728,7 @@ typedef struct _KUSER_SHARED_DATA
     volatile ULONG64 InterruptTimeBias;
     volatile ULONG64 QpcBias;
 
-    volatile ULONG ActiveProcessorCount;
+    ULONG ActiveProcessorCount;
     volatile UCHAR ActiveGroupCount;
     UCHAR Reserved9;
     union
@@ -2772,10 +2777,11 @@ C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, LastSystemRITEventTickCount) == 0x2e4);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, NumberOfPhysicalPages) == 0x2e8);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, SafeBootMode) == 0x2ec);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, TestRetInstruction) == 0x2f8);
-C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, SystemCallPad) == 0x308);
+C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, SystemCallPad) == 0x310);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, TickCount) == 0x320);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, TickCountQuad) == 0x320);
 C_ASSERT(FIELD_OFFSET(KUSER_SHARED_DATA, XState) == 0x3d8);
+C_ASSERT(sizeof(KUSER_SHARED_DATA) == 0x708);
 
 #define USER_SHARED_DATA ((KUSER_SHARED_DATA * const)0x7ffe0000)
 

--- a/phnt/include/ntexapi.h
+++ b/phnt/include/ntexapi.h
@@ -35,8 +35,6 @@ NtSetSystemEnvironmentValue(
     _In_ PUNICODE_STRING VariableValue
     );
 
-#if (PHNT_VERSION >= PHNT_WIN8)
-
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
@@ -67,8 +65,6 @@ NtEnumerateSystemEnvironmentValuesEx(
     _Out_ PVOID Buffer,
     _Inout_ PULONG BufferLength
     );
-
-#endif
 
 // EFI
 

--- a/phnt/include/ntldr.h
+++ b/phnt/include/ntldr.h
@@ -44,8 +44,8 @@ typedef struct _LDR_DDAG_NODE
     LIST_ENTRY Modules;
     PLDR_SERVICE_TAG_RECORD ServiceTagList;
     ULONG LoadCount;
-    ULONG ReferenceCount;
-    ULONG DependencyCount;
+    ULONG LoadWhileUnloadingCount;
+    ULONG LowestLink;
     union
     {
         LDRP_CSLIST Dependencies;
@@ -55,7 +55,6 @@ typedef struct _LDR_DDAG_NODE
     LDR_DDAG_STATE State;
     SINGLE_LIST_ENTRY CondenseLink;
     ULONG PreorderNumber;
-    ULONG LowestLink;
 } LDR_DDAG_NODE, *PLDR_DDAG_NODE;
 
 // rev
@@ -167,6 +166,7 @@ typedef struct _LDR_DATA_TABLE_ENTRY
     LDR_DLL_LOAD_REASON LoadReason;
     ULONG ImplicitPathOptions;
     ULONG ReferenceCount;
+    ULONG DependentLoadFlags;
 } LDR_DATA_TABLE_ENTRY, *PLDR_DATA_TABLE_ENTRY;
 
 typedef BOOLEAN (NTAPI *PDLL_INIT_ROUTINE)(

--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -165,9 +165,7 @@ typedef enum _PROCESSINFOCLASS
     ProcessCommitReleaseInformation, // PROCESS_COMMIT_RELEASE_INFORMATION
     ProcessDefaultCpuSetsInformation,
     ProcessAllowedCpuSetsInformation,
-    ProcessReserved1Information,
-    ProcessReserved2Information,
-    ProcessSubsystemProcess, // 70
+    ProcessSubsystemProcess, // 68
     ProcessJobMemoryInformation, // PROCESS_JOB_MEMORY_INFO
     ProcessInPrivate, // since THRESHOLD2
     ProcessRaiseUMExceptionOnInvalidHandleClose,
@@ -220,6 +218,7 @@ typedef enum _THREADINFOCLASS
     ThreadSelectedCpuSets,
     ThreadSystemThreadInformation, // q: SYSTEM_THREAD_INFORMATION // 40
     ThreadActualGroupAffinity, // since THRESHOLD2
+    ThreadDynamicCodePolicyInfo,
     MaxThreadInfoClass
 } THREADINFOCLASS;
 #endif


### PR DESCRIPTION
This pull request fixes the following PHNT header issues:

* Updates PEB,  PEB32, TEB,  TEB32, KUSER_SHARED_DATA, LDR_DDAG_NODE and LDR_DATA_TABLE_ENTRY structures for Windows 10 builds 10240, 10586 and 14393 (at present these structures only support Windows 8 and require these fixes).

* Fixes some PROCESSINFOCLASS fields using the wrong IDs. 
* Updates THREADINFOCLASS with new IDs.

* Removes a field from the PEB32 structure that does not exist.
* Fixes all inconsistencies with the PEB32 structure.

* Adds C_ASSERTs for reliability.


