### PR TITLE
PhEnumServices bug

### DIFF
--- a/phlib/svcsup.c
+++ b/phlib/svcsup.c
@@ -92,7 +92,22 @@ PVOID PhEnumServices(
     ULONG servicesReturned;
 
     if (!Type)
-        Type = WindowsVersion >= WINDOWS_10 && PhOsVersion.dwBuildNumber >= 10586 ? SERVICE_TYPE_ALL : (SERVICE_DRIVER | SERVICE_WIN32);
+    {
+        if (WindowsVersion >= WINDOWS_10)
+        {
+            Type = PhOsVersion.dwBuildNumber >= 10586 ? SERVICE_TYPE_ALL : 
+                SERVICE_WIN32 |
+                SERVICE_DRIVER |
+                SERVICE_INTERACTIVE_PROCESS |
+                SERVICE_USER_SERVICE |
+                SERVICE_USERSERVICE_INSTANCE;
+        }
+        else
+        {
+            Type = SERVICE_DRIVER | SERVICE_WIN32;
+        }
+    }
+
     if (!State)
         State = SERVICE_STATE_ALL;
 

--- a/phlib/svcsup.c
+++ b/phlib/svcsup.c
@@ -92,7 +92,7 @@ PVOID PhEnumServices(
     ULONG servicesReturned;
 
     if (!Type)
-        Type = WindowsVersion >= WINDOWS_10 ? SERVICE_TYPE_ALL : (SERVICE_DRIVER | SERVICE_WIN32);
+        Type = WindowsVersion >= WINDOWS_10 && PhOsVersion.dwBuildNumber >= 10586 ? SERVICE_TYPE_ALL : (SERVICE_DRIVER | SERVICE_WIN32);
     if (!State)
         State = SERVICE_STATE_ALL;
 


### PR DESCRIPTION
The 14393 SDK changed the definition of SERVICE_TYPE_ALL to include a new service type of SERVICE_PKG_SERVICE.

However, this prevents Process Hacker from enumerating services on Windows 10 build 10240 (RTM) resulting in an empty services tab.

This PR includes a version check for builds 10586 and above and fixes the issue with an empty services tab on older builds of Windows 10.