### PR TITLE
[WIP] Heuristic to locate and tag the CFG Bitmap in memory view

### DIFF
--- a/ProcessHacker/include/memprv.h
+++ b/ProcessHacker/include/memprv.h
@@ -20,7 +20,8 @@ typedef enum _PH_MEMORY_REGION_TYPE
     HeapRegion,
     Heap32Region,
     HeapSegmentRegion,
-    HeapSegment32Region
+    HeapSegment32Region,
+    CfgBitmapRegion
 } PH_MEMORY_REGION_TYPE;
 
 typedef struct _PH_MEMORY_ITEM

--- a/ProcessHacker/memlist.c
+++ b/ProcessHacker/memlist.c
@@ -424,6 +424,8 @@ PPH_STRING PhpGetMemoryRegionUseText(
     case HeapSegment32Region:
         return PhFormatString(L"Heap segment%s (ID %u)",
             type == HeapSegment32Region ? L" 32-bit" : L"", (ULONG)MemoryItem->u.HeapSegment.HeapItem->u.Heap.Index + 1);
+    case CfgBitmapRegion:
+        return PhFormatString(L"CFG Bitmap");
     default:
         return PhReferenceEmptyString();
     }


### PR DESCRIPTION
This PR is a proposal to tag the CFG bitmap memory allocation in the "Memory" view of a process. It might help puzzled developers to understand why there is a giant 2 TB  memory allocation in their process memory map.

64-bit process which are CFG-aware allocate a 2 TB reserved memory
map to store the CFG bitmap used to determinate the valid target call.

This bitmap base address cannot - yet - be located using public API (that
I know of) therefore we need to rely on heuristics.

Before : 
![cfg_bitmap_naked](https://cloud.githubusercontent.com/assets/2520861/25123455/ab43bd78-2428-11e7-8549-af3f2bc14136.PNG)

After:
![cfg_bitmap_tagged](https://cloud.githubusercontent.com/assets/2520861/25123473/b95b0e52-2428-11e7-9403-807c28875176.PNG)
