### PR TITLE
phlib: Fix a potential exception when calling NtQueryObject

### DIFF
--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -142,12 +142,13 @@ NTSTATUS PhpGetObjectBasicInformation(
     }
     else
     {
+        ULONG returnLength;
         status = NtQueryObject(
             Handle,
             ObjectBasicInformation,
             BasicInformation,
             sizeof(OBJECT_BASIC_INFORMATION),
-            NULL
+            &returnLength
             );
 
         if (NT_SUCCESS(status))
@@ -1394,7 +1395,7 @@ NTSTATUS PhEnumObjectTypes(
 {
     NTSTATUS status;
     PVOID buffer;
-    ULONG bufferSize;
+    ULONG bufferSize, returnLength;
 
     bufferSize = 0x1000;
     buffer = PhAllocate(bufferSize);
@@ -1404,7 +1405,7 @@ NTSTATUS PhEnumObjectTypes(
         ObjectTypesInformation,
         buffer,
         bufferSize,
-        NULL
+        &returnLength
         )) == STATUS_INFO_LENGTH_MISMATCH)
     {
         PhFree(buffer);


### PR DESCRIPTION
* Under some circumstances, `NtQueryObject()` will produce a NULL pointer exception if the last parameter is NULL:
![image3](https://cloud.githubusercontent.com/assets/1206968/25549285/e570a432-2c68-11e7-8e69-48cc410e2c78.png)
* I was able to consistently experience this behaviour, on Windows 10 x64 (Build 15063) when running the `Debug|Win32` version of PH from an __elevated__ VS2017, and then checking the properties of one of the `svchost.exe` services.
* Of course, one is not supposed to run the Win32 version of PH on x64, and as far as I could see, the x64 version does not suffer from this problem, but this is an easy fix to add.