### PR TITLE
Add cfg support for wow64 process

### DIFF
--- a/ProcessHacker/include/memprv.h
+++ b/ProcessHacker/include/memprv.h
@@ -21,7 +21,8 @@ typedef enum _PH_MEMORY_REGION_TYPE
     Heap32Region,
     HeapSegmentRegion,
     HeapSegment32Region,
-    CfgBitmapRegion
+    CfgBitmapRegion,
+    CfgBitmap32Region
 } PH_MEMORY_REGION_TYPE;
 
 typedef struct _PH_MEMORY_ITEM

--- a/ProcessHacker/memlist.c
+++ b/ProcessHacker/memlist.c
@@ -425,7 +425,9 @@ PPH_STRING PhpGetMemoryRegionUseText(
         return PhFormatString(L"Heap segment%s (ID %u)",
             type == HeapSegment32Region ? L" 32-bit" : L"", (ULONG)MemoryItem->u.HeapSegment.HeapItem->u.Heap.Index + 1);
     case CfgBitmapRegion:
-        return PhFormatString(L"CFG Bitmap");
+    case CfgBitmap32Region:
+        return PhFormatString(L"CFG Bitmap%s",
+            type == CfgBitmap32Region ? L" 32-bit" : L"");
     default:
         return PhReferenceEmptyString();
     }

--- a/phlib/include/mapimg.h
+++ b/phlib/include/mapimg.h
@@ -10,7 +10,11 @@ typedef struct _PH_MAPPED_IMAGE
     PVOID ViewBase;
     SIZE_T Size;
 
-    PIMAGE_NT_HEADERS NtHeaders;
+    union {
+        PIMAGE_NT_HEADERS32 NtHeaders32;
+        PIMAGE_NT_HEADERS NtHeaders;
+    };
+
     ULONG NumberOfSections;
     PIMAGE_SECTION_HEADER Sections;
     USHORT Magic;

--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -185,8 +185,7 @@ VOID PvPeProperties(
         }
 
         // CFG page
-        if ((PvMappedImage.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC) &&
-            (PvMappedImage.NtHeaders->OptionalHeader.DllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF))
+        if (PvMappedImage.NtHeaders->OptionalHeader.DllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)
         {
             newPage = PvCreatePropPageContext(
                 MAKEINTRESOURCE(IDD_PECFG),
@@ -1144,8 +1143,8 @@ INT_PTR CALLBACK PvpPeCgfDlgProc(
             PhSetListViewStyle(lvHandle, FALSE, TRUE);
             PhSetControlTheme(lvHandle, L"explorer");
 
-            PhAddListViewColumn(lvHandle, 0, 0, 0, LVCFMT_LEFT ,  40, L"#");
-            PhAddListViewColumn(lvHandle, 1, 1, 1, LVCFMT_RIGHT, 80, L"RVA");
+            PhAddListViewColumn(lvHandle, 0, 0, 0, LVCFMT_LEFT , 40,  L"#");
+            PhAddListViewColumn(lvHandle, 1, 1, 1, LVCFMT_RIGHT, 80,  L"VA");
             PhAddListViewColumn(lvHandle, 2, 2, 2, LVCFMT_LEFT , 250, L"Name");
             PhAddListViewColumn(lvHandle, 3, 3, 3, LVCFMT_LEFT , 100, L"Flags");
             PhSetExtendedListView(lvHandle);


### PR DESCRIPTION
Following the remark made by @ionescu007 (https://github.com/processhacker2/processhacker2/pull/124#issuecomment-297221437), I've added the support for tagging memory page which belongs to wow64 CFG bitmaps. Here an example :

![sans titre](https://cloud.githubusercontent.com/assets/2520861/25682160/68382808-3057-11e7-97eb-43a0f0c0e6ef.png)


* Locate and tag `CFG` bitmap memory page (both x86 and x64) for wow64
  processes
* Add `CFG` entries parsing for 32-bit executables in ```peview```
* Add unnamed union in `PH_MAPPED_IMAGE` in order to selectively read a
  `IMAGE_NT_HEADER` as 32 bit (could also have used a C-style cast)
* Rename `CFG` page `"RVA"` column to `"VA"` since we read Virtual Adresses (see PR https://github.com/processhacker2/processhacker2/pull/125)

I've not tested on build `14393`, feel free to tell me if something seem fishy to you.

Cheers,

Lucas.

