### PR TITLE
Fix search box font size on high DPI displays

### DIFF
--- a/ProcessHacker/searchbox.c
+++ b/ProcessHacker/searchbox.c
@@ -83,7 +83,7 @@ VOID PhpSearchInitializeFont(
     if (Context->WindowFont) 
         DeleteObject(Context->WindowFont);
 
-    Context->WindowFont = PhCreateCommonFont(PH_SCALE_DPI(10), FW_MEDIUM, Context->WindowHandle);
+    Context->WindowFont = PhCreateCommonFont(10, FW_MEDIUM, Context->WindowHandle);
 }
 
 VOID PhpSearchInitializeTheme(


### PR DESCRIPTION
On High DPI displays, the font size used by the _Find Handles or DLLs_ is too big, which makes the ability to enter text difficult:
![image3](https://cloud.githubusercontent.com/assets/1206968/25682874/b41c5308-3051-11e7-9aca-8c7c90ec14df.png)
It therefore seems that the call to `PH_SCALE_DPI()` is unwarranted. This patch removes it.

Tested on Windows 10 x64 Build 15063 (Creators Update) with a default UI scale of 200%.