### PR TITLE
Add support for undecorate C++ names

### DIFF
--- a/phlib/include/symprv.h
+++ b/phlib/include/symprv.h
@@ -296,6 +296,22 @@ PhWalkThreadStack(
     _In_opt_ PVOID Context
     );
 
+PHLIBAPI
+PPH_STRING
+NTAPI
+PhUndecorateName(
+	_In_ HANDLE ProcessHandle,
+	_In_ PCSTR DecoratedName
+);
+
+PHLIBAPI
+PPH_STRING
+NTAPI
+PhUndecorateNameW(
+	_In_ HANDLE ProcessHandle,
+	_In_ PWSTR DecoratedName
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/phlib/include/symprvp.h
+++ b/phlib/include/symprvp.h
@@ -167,4 +167,18 @@ typedef BOOL (CALLBACK *_SymbolServerSetOptions)(
     _In_ ULONG64 data
     );
 
+typedef DWORD(WINAPI *_UnDecorateSymbolName)(
+	_In_  PCSTR DecoratedName,
+	_Out_ PSTR  UnDecoratedName,
+	_In_  DWORD  UndecoratedLength,
+	_In_  DWORD  Flags
+	);
+
+typedef DWORD(WINAPI *_UnDecorateSymbolNameW)(
+	_In_  PCWSTR DecoratedName,
+	_Out_ PWSTR  UnDecoratedName,
+	_In_  DWORD  UndecoratedLength,
+	_In_  DWORD  Flags
+	);
+
 #endif


### PR DESCRIPTION
Add support to undecorate C++ names in `phlib`. 
Example : 
    `?_Mtx_unlock@threads@stdext@@YAXPEAX@Z` => `void stdext::threads::_Mtx_unlock(void *)`

Modifs : 

* `phlib` : Add `PhUndecorateName(W)`
* `peviewer` : undecorate names on import and export entries (not on CFG entries since we already rely on the symbol provider)

Peview:

![image](https://cloud.githubusercontent.com/assets/2520861/25971613/2de988da-369d-11e7-97eb-34c6d1bfba9a.png)


NB : there is a MFC bug where the ListView has a hard limit of 260 char to display for text.