### PR TITLE
Add shortcut keys

### DIFF
--- a/ProcessHacker/ProcessHacker.rc
+++ b/ProcessHacker/ProcessHacker.rc
@@ -111,11 +111,11 @@ BEGIN
         MENUITEM "System &information\aCtrl+I", ID_VIEW_SYSTEMINFORMATION
         POPUP "&Tray icons"
         BEGIN
-            MENUITEM "CPU history",                 ID_TRAYICONS_CPUHISTORY
-            MENUITEM "CPU usage",                   ID_TRAYICONS_CPUUSAGE
-            MENUITEM "I/O history",                 ID_TRAYICONS_IOHISTORY
-            MENUITEM "Commit charge history",       ID_TRAYICONS_COMMITHISTORY
-            MENUITEM "Physical memory history",     ID_TRAYICONS_PHYSICALMEMORYHISTORY
+            MENUITEM "CPU &history",                 ID_TRAYICONS_CPUHISTORY
+            MENUITEM "CPU &usage",                   ID_TRAYICONS_CPUUSAGE
+            MENUITEM "&I/O history",                 ID_TRAYICONS_IOHISTORY
+            MENUITEM "&Commit charge history",       ID_TRAYICONS_COMMITHISTORY
+            MENUITEM "&Physical memory history",     ID_TRAYICONS_PHYSICALMEMORYHISTORY
         END
         MENUITEM SEPARATOR
         MENUITEM "<section placeholder>",       ID_VIEW_SECTIONPLACEHOLDER
@@ -152,7 +152,7 @@ BEGIN
         MENUITEM "Hidden processes",            ID_TOOLS_HIDDENPROCESSES
         MENUITEM "Inspect executable file...",  ID_TOOLS_INSPECTEXECUTABLEFILE
         MENUITEM "Pagefiles",                   ID_TOOLS_PAGEFILES
-        MENUITEM "Start Task Manager",          ID_TOOLS_STARTTASKMANAGER
+        MENUITEM "Start &Task Manager",          ID_TOOLS_STARTTASKMANAGER
     END
     POPUP "&Users"
     BEGIN
@@ -301,9 +301,9 @@ BEGIN
                 MENUITEM "Low",                         ID_PAGEPRIORITY_LOW
                 MENUITEM "Very low",                    ID_PAGEPRIORITY_VERYLOW
             END
-            MENUITEM "Reduce working set",          ID_MISCELLANEOUS_REDUCEWORKINGSET
-            MENUITEM "Run as...",                   ID_MISCELLANEOUS_RUNAS
-            MENUITEM "Run as this user...",         ID_MISCELLANEOUS_RUNASTHISUSER
+            MENUITEM "Reduce working &set",          ID_MISCELLANEOUS_REDUCEWORKINGSET
+            MENUITEM "&Run as...",                   ID_MISCELLANEOUS_RUNAS
+            MENUITEM "Run &as this user...",         ID_MISCELLANEOUS_RUNASTHISUSER
         END
         POPUP "&Window"
         BEGIN

--- a/ProcessHacker/mwpgsrv.c
+++ b/ProcessHacker/mwpgsrv.c
@@ -108,7 +108,7 @@ BOOLEAN PhMwpServicesPageCallback(
             ULONG startIndex = menuInfo->StartIndex;
             PPH_EMENU_ITEM menuItem;
 
-            PhInsertEMenuItem(menu, PhCreateEMenuItem(0, ID_VIEW_HIDEDRIVERSERVICES, L"Hide driver services", NULL, NULL), startIndex);
+            PhInsertEMenuItem(menu, PhCreateEMenuItem(0, ID_VIEW_HIDEDRIVERSERVICES, L"&Hide driver services", NULL, NULL), startIndex);
 
             if (DriverFilterEntry && (menuItem = PhFindEMenuItem(menu, 0, NULL, ID_VIEW_HIDEDRIVERSERVICES)))
                 menuItem->Flags |= PH_EMENU_CHECKED;

--- a/plugins/ExtraPlugins/main.c
+++ b/plugins/ExtraPlugins/main.c
@@ -253,7 +253,7 @@ VOID NTAPI MainMenuInitializingCallback(
 
     if (pluginMenu = PhFindEMenuItem(menuInfo->Menu, PH_EMENU_FIND_DESCEND, NULL, PHAPP_ID_HACKER_PLUGINS))
     {
-        PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, 0, pluginMenu->Id, L"Plugins... (Beta)", NULL), PhIndexOfEMenuItem(menuInfo->Menu, pluginMenu));
+        PhInsertEMenuItem(menuInfo->Menu, PhPluginCreateEMenuItem(PluginInstance, 0, pluginMenu->Id, L"&Plugins... (Beta)", NULL), PhIndexOfEMenuItem(menuInfo->Menu, pluginMenu));
         PhRemoveEMenuItem(menuInfo->Menu, pluginMenu, 0);    
     }
 }

--- a/plugins/UserNotes/main.c
+++ b/plugins/UserNotes/main.c
@@ -870,8 +870,8 @@ VOID AddSavePriorityMenuItemsAndHook(
 
         // Insert standard menu-items
         PhInsertEMenuItem(affinityMenuItem, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, NULL, NULL), -1);
-        PhInsertEMenuItem(affinityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_AFFINITY_SAVE_ID, PhaFormatString(L"Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
-        PhInsertEMenuItem(affinityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_AFFINITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save for this command line", NULL), -1);
+        PhInsertEMenuItem(affinityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_AFFINITY_SAVE_ID, PhaFormatString(L"&Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
+        PhInsertEMenuItem(affinityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_AFFINITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save &for this command line", NULL), -1);
 
         if (!ProcessItem->CommandLine)
             saveForCommandLineMenuItem->Flags |= PH_EMENU_DISABLED;
@@ -890,8 +890,8 @@ VOID AddSavePriorityMenuItemsAndHook(
     if (priorityMenuItem = PhFindEMenuItem(MenuInfo->Menu, 0, L"Priority", 0))
     {
         PhInsertEMenuItem(priorityMenuItem, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, NULL, NULL), -1);
-        PhInsertEMenuItem(priorityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_PRIORITY_SAVE_ID, PhaFormatString(L"Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
-        PhInsertEMenuItem(priorityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_PRIORITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save for this command line", NULL), -1);
+        PhInsertEMenuItem(priorityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_PRIORITY_SAVE_ID, PhaFormatString(L"&Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
+        PhInsertEMenuItem(priorityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_PRIORITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save &for this command line", NULL), -1);
 
         if (!ProcessItem->CommandLine)
             saveForCommandLineMenuItem->Flags |= PH_EMENU_DISABLED;
@@ -910,8 +910,8 @@ VOID AddSavePriorityMenuItemsAndHook(
     if (ioPriorityMenuItem = PhFindEMenuItem(MenuInfo->Menu, 0, L"I/O Priority", 0))
     {
         PhInsertEMenuItem(ioPriorityMenuItem, PhPluginCreateEMenuItem(PluginInstance, PH_EMENU_SEPARATOR, 0, NULL, NULL), -1);
-        PhInsertEMenuItem(ioPriorityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_IO_PRIORITY_SAVE_ID, PhaFormatString(L"Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
-        PhInsertEMenuItem(ioPriorityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_IO_PRIORITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save for this command line", NULL), -1);
+        PhInsertEMenuItem(ioPriorityMenuItem, saveMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_IO_PRIORITY_SAVE_ID, PhaFormatString(L"&Save for %s", ProcessItem->ProcessName->Buffer)->Buffer, NULL), -1);
+        PhInsertEMenuItem(ioPriorityMenuItem, saveForCommandLineMenuItem = PhPluginCreateEMenuItem(PluginInstance, 0, PROCESS_IO_PRIORITY_SAVE_FOR_THIS_COMMAND_LINE_ID, L"Save &for this command line", NULL), -1);
 
         if (!ProcessItem->CommandLine)
             saveForCommandLineMenuItem->Flags |= PH_EMENU_DISABLED;


### PR DESCRIPTION
Adds shortcut keys to various menu items. Some of these work already without the shortcut key being explicitly set, however I can't imagine that I'm the only one that looks for the underline in the menus.

- View\Tray Icons contents
  - CPU **​*h*​**istory
  - CPU **​*u*​**sage
  - **​*I*​**/O history
  - **​*C*​**ommit charge history
  - **​*P*​**hysical memory history
- Tools\Start **​*T*​**ask Manager
- Process Context Menu\Miscellaneous contents
  - Reduce working **​*s*​**et
  - **​*R*​**un as...
  - Run **​*a*​**s this user...
- Services tab - View\**​*H*​**ide driver services
- Content menu items 'Affinity', 'Priority', 'I/O Priority' sub-items:
  - **​*S*​**ave for %s
  - Save **​*f*​**or this command line

I've tested the code and it compiles/runs fine on my system.